### PR TITLE
Adapt configuration example for ESPHome 2024.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ logger:
   level: NONE
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
There was a slight change to the config when updating to ESPHome 2024.6. This fixes the `ota` configuration section.

~~Not sure what char was changed at the end of the file as I used the browser to perform the edit?~~ Re-did the change in another editor and the file ending diff is no more.