### PR TITLE
Update visual hot water defaults.

### DIFF
--- a/comfortzone-package.yaml
+++ b/comfortzone-package.yaml
@@ -142,6 +142,9 @@ climate:
       name: "ComfortZone EX50 heating"
     water_heater_climate:
       name: "ComfortZone EX50 hot water"
+      visual:
+        min_temperature: 30
+        max_temperature: 65
 
 # Needed to keep track of sensor offset changes
 time:


### PR DESCRIPTION
The default climate temperature values are between 10 and 30 degrees. That might be sufficient for the _heating_ component but _hot water_ requires a higher interval.